### PR TITLE
Replace ViewOnlyAccess with ReadOnlyAccess.

### DIFF
--- a/cloudformation/cfa/duckbill-cfa-iam-role.yml
+++ b/cloudformation/cfa/duckbill-cfa-iam-role.yml
@@ -33,7 +33,7 @@ Resources:
             Principal:
               AWS: 753095100886
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/job-function/ViewOnlyAccess
+        - arn:aws:iam::aws:policy/job-function/ReadOnlyAccess
         - !Ref DuckbillGroupResourceDiscoveryPolicy
         - !Ref DuckbillGroupCURIngestPipelinePolicy
 

--- a/terraform/cfa/duckbill-cfa-iam-role.tf
+++ b/terraform/cfa/duckbill-cfa-iam-role.tf
@@ -107,7 +107,7 @@ resource "aws_iam_policy" "DuckbillGroupCURIngestPipeline_policy" {
 
 resource "aws_iam_role_policy_attachment" "duckbill-attach-ViewOnlyAccess" {
   role       = "${aws_iam_role.DuckbillGroupRole.name}"
-  policy_arn = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"
+  policy_arn = "arn:aws:iam::aws:policy/job-function/ReadOnlyAccess"
 }
 
 resource "aws_iam_role_policy_attachment" "duckbill-attach-DuckbillGroupResourceDiscovery_policy" {


### PR DESCRIPTION
Replace `ViewOnlyAccess` policy with `ReadOnlyAccess` policy because `ViewOnlyAccess` is too restrictive. Until we sort out what supplementary policy actions we need to allow alongside `ViewOnlyAccess`, `ReadOnlyAccess` provides a solid catch-all.